### PR TITLE
Add ratio for `attacker.data()`, `attacker.edge_flips()`, and `attacker.feat_flips()`

### DIFF
--- a/greatx/attack/targeted/pgd_attack.py
+++ b/greatx/attack/targeted/pgd_attack.py
@@ -101,6 +101,7 @@ class PGDAttack(TargetedAttacker, Surrogate):
         num_budgets: Optional[Union[float, int]] = None,
         direct_attack: bool = True,
         base_lr: float = 0.1,
+        grad_clip: Optional[float] = None,
         epochs: int = 200,
         ce_loss: bool = False,
         sample_epochs: int = 20,
@@ -129,6 +130,9 @@ class PGDAttack(TargetedAttacker, Surrogate):
             by default None
         base_lr : float, optional
             the base learning rate for PGD training, by default 0.1
+        grad_clip : float, optional
+            gradient clipping for the computed gradients,
+            by default None
         epochs : int, optional
             the number of epochs for PGD training, by default 200
         ce_loss : bool, optional
@@ -183,6 +187,11 @@ class PGDAttack(TargetedAttacker, Surrogate):
                           disable=disable):
             lr = base_lr * self.num_budgets / math.sqrt(epoch + 1)
             gradients = self.compute_gradients(perturbations)
+
+            if grad_clip is not None:
+                grad_len_sq = gradients.square().sum()
+                if grad_len_sq > grad_clip * grad_clip:
+                    gradients *= grad_clip / grad_len_sq.sqrt()
 
             with torch.no_grad():
                 perturbations += lr * gradients

--- a/greatx/attack/targeted/pgd_attack.py
+++ b/greatx/attack/targeted/pgd_attack.py
@@ -188,10 +188,7 @@ class PGDAttack(TargetedAttacker, Surrogate):
             lr = base_lr * self.num_budgets / math.sqrt(epoch + 1)
             gradients = self.compute_gradients(perturbations)
 
-            if grad_clip is not None:
-                grad_len_sq = gradients.square().sum()
-                if grad_len_sq > grad_clip * grad_clip:
-                    gradients *= grad_clip / grad_len_sq.sqrt()
+            gradients = self.clip(gradients, grad_clip)
 
             with torch.no_grad():
                 perturbations += lr * gradients

--- a/greatx/attack/targeted/pgd_attack.py
+++ b/greatx/attack/targeted/pgd_attack.py
@@ -188,7 +188,7 @@ class PGDAttack(TargetedAttacker, Surrogate):
             lr = base_lr * self.num_budgets / math.sqrt(epoch + 1)
             gradients = self.compute_gradients(perturbations)
 
-            gradients = self.clip(gradients, grad_clip)
+            gradients = self.clip_grad(gradients, grad_clip)
 
             with torch.no_grad():
                 perturbations += lr * gradients

--- a/greatx/attack/untargeted/pgd_attack.py
+++ b/greatx/attack/untargeted/pgd_attack.py
@@ -1,6 +1,6 @@
 import math
 from functools import partial
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 import torch
@@ -134,6 +134,7 @@ class PGDAttack(UntargetedAttacker, Surrogate):
         num_budgets: Union[int, float] = 0.05,
         *,
         base_lr: float = 0.1,
+        grad_clip: Optional[float] = None,
         epochs: int = 200,
         ce_loss: bool = False,
         sample_epochs: int = 20,
@@ -151,6 +152,9 @@ class PGDAttack(UntargetedAttacker, Surrogate):
             or int (number), by default 0.05
         base_lr : float, optional
             the base learning rate for PGD training, by default 0.1
+        grad_clip : float, optional
+            gradient clipping for the computed gradients,
+            by default None
         epochs : int, optional
             the number of epochs for PGD training, by default 200
         ce_loss : bool, optional
@@ -190,6 +194,11 @@ class PGDAttack(UntargetedAttacker, Surrogate):
                           disable=disable):
             lr = base_lr * self.num_budgets / math.sqrt(epoch + 1)
             gradients = self.compute_gradients(perturbations)
+
+            if grad_clip is not None:
+                grad_len_sq = gradients.square().sum()
+                if grad_len_sq > grad_clip * grad_clip:
+                    gradients *= grad_clip / grad_len_sq.sqrt()
 
             with torch.no_grad():
                 perturbations += lr * gradients

--- a/greatx/attack/untargeted/pgd_attack.py
+++ b/greatx/attack/untargeted/pgd_attack.py
@@ -195,7 +195,7 @@ class PGDAttack(UntargetedAttacker, Surrogate):
             lr = base_lr * self.num_budgets / math.sqrt(epoch + 1)
             gradients = self.compute_gradients(perturbations)
 
-            gradients = self.clip(gradients, grad_clip)
+            gradients = self.clip_grad(gradients, grad_clip)
 
             with torch.no_grad():
                 perturbations += lr * gradients

--- a/greatx/attack/untargeted/pgd_attack.py
+++ b/greatx/attack/untargeted/pgd_attack.py
@@ -195,10 +195,7 @@ class PGDAttack(UntargetedAttacker, Surrogate):
             lr = base_lr * self.num_budgets / math.sqrt(epoch + 1)
             gradients = self.compute_gradients(perturbations)
 
-            if grad_clip is not None:
-                grad_len_sq = gradients.square().sum()
-                if grad_len_sq > grad_clip * grad_clip:
-                    gradients *= grad_clip / grad_len_sq.sqrt()
+            gradients = self.clip(gradients, grad_clip)
 
             with torch.no_grad():
                 perturbations += lr * gradients


### PR DESCRIPTION
This PR allows specifying an argument `ratio` for `attacker.edge_flips()`, and `attacker.feat_flips()`, which determines how many generated perturbations were used for further evaluation/visualization. Correspondingly,  `attacker.data()` holds `edge_ratio` and `feat_ratio` for these two methods when constructing perturbed graph.

+ Example
```python
attacker = ...
attacker.reset()
attacker.attack(...)

# Case1: Only 50% of generated edge perturbations were used
trainer.evaluate(attacker.data(edge_ratio=0.5), mask=...)

# Case2: Only 50% of generated feature perturbations were used
trainer.evaluate(attacker.data(feat_ratio=0.5), mask=...)

# NOTE: both arguments can be used simultaneously
```