### PR TITLE
Fix a venue of FeaturePropagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ More details of literatures and the official codes can be found at [Awesome Grap
 | **DropEdge**           | *Rong et al.* [DropEdge: Towards Deep Graph Convolutional Networks on Node Classification](https://arxiv.org/abs/1907.10903), *ICLR'20*                                 | [[**Example**]](https://github.com/EdisonLeeeee/GreatX/blob/master/examples/models/supervised/drop_edge.py) |
 | **DropNode**           | *You et al.* [Graph Contrastive Learning with Augmentations](https://arxiv.org/abs/2010.13902), *NeurIPS'20*                                                            | [[**Example**]](https://github.com/EdisonLeeeee/GreatX/blob/master/examples/models/supervised/drop_node.py) |
 | **DropPath**           | *Li et al.* [MaskGAE: Masked Graph Modeling Meets Graph Autoencoders](https://arxiv.org/abs/2205.10053), *arXiv'22*'                                                    | [[**Example**]](https://github.com/EdisonLeeeee/GreatX/blob/master/examples/models/supervised/drop_path.py) |
-| **FeaturePropagation** | *Rossi et al.* [On the Unreasonable Effectiveness of Feature propagation in Learning on Graphs with Missing Node Features](https://arxiv.org/abs/2111.12128), *ICLR'21* | [[**Example**]](https://github.com/EdisonLeeeee/GreatX/blob/master/examples/defense/feature_propagation.py) |
+| **FeaturePropagation** | *Rossi et al.* [On the Unreasonable Effectiveness of Feature propagation in Learning on Graphs with Missing Node Features](https://arxiv.org/abs/2111.12128), *arXiv'21* | [[**Example**]](https://github.com/EdisonLeeeee/GreatX/blob/master/examples/defense/feature_propagation.py) |
 
 
 ## Miscellaneous

--- a/greatx/defense/feature_propagation.py
+++ b/greatx/defense/feature_propagation.py
@@ -14,7 +14,7 @@ class FeaturePropagation(BaseTransform):
     from the `"On the Unreasonable Effectiveness
     of Feature propagation in Learning
     on Graphs with Missing Node Features"
-    <https://arxiv.org/abs/2111.12128>`_ paper (ICLR'21)
+    <https://arxiv.org/abs/2111.12128>`_ paper (arXiv'21)
 
     Parameters
     ----------


### PR DESCRIPTION
Rossi's FeaturePropagation paper was submitted to _ICLR'21_ but was rejected. So how about updating with _arXiv_? This paper has not yet been accepted by other conferences.